### PR TITLE
Change argocdapp prefix from gabbar-dev to gabbar-preview

### DIFF
--- a/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
+++ b/01-gabbar/02-stakater-nordmart-review-ui/00-build/values.yaml
@@ -91,6 +91,8 @@ pipeline-charts:
           value: $(params.gitrepositoryurl)
         - name: timeout
           value: "120"
+        - name: argoAppPrefix
+          value: gabbar-preview
         workspaces:
         - name: source
           workspace: source


### PR DESCRIPTION
Change argocdapp prefix from gabbar-dev to gabbar-preview. 
Pipeline task syncs the wrong app because of incorrect prefix.