### PR TITLE
Use arogcd-app-get with arg refresh to trigger sync as a workaround of known issue

### DIFF
--- a/03-sre/01-dev-test/tekton-config/clustertasks/stakater-app-sync-and-wait-v1.yaml
+++ b/03-sre/01-dev-test/tekton-config/clustertasks/stakater-app-sync-and-wait-v1.yaml
@@ -65,7 +65,7 @@ spec:
           echo "It is a PR"
           ENVIRONMENT="preview"
           argocd login "$ARGOCD_SERVER" --username="$ARGOCD_USERNAME" --password="$ARGOCD_PASSWORD"
-          argocd app sync "$TENANT-$ENVIRONMENT-$(params.repoName)"
+          argocd app get "$TENANT-$ENVIRONMENT-$(params.repoName)" --refresh
           argocd app wait "$TENANT-$ENVIRONMENT-$(params.repoName)" --health --sync
           while [[ "$SECONDS" -lt $(params.timeout) ]]
           do 


### PR DESCRIPTION
Use arogcd-app-get with arg: refresh to trigger sync as a workaround of known issue